### PR TITLE
fix setup.py and mdt.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pip3 install git+https://github.com/riita10069/md-translate.git
 Options:
   --path PATH                     directory or file path where you want to
                                   translate  [required]
+  --r                             translate recursively for subdirectories
   --src-lang [af|sq|am|ar|hy|az|bn|bs|bg|ca|zh|zh-TW|hr|cs|da|fa-AF|nl|en|et|fa|tl|fi|fr|fr-CA|ka|de|el|gu|ht|ha|he|hi|hu|is|id|ga|it|ja|kn|kk|ko|lv|lt|mk|ms|ml|mt|mr|mn|no|ps|pl|pt|pt-PT|pa|ro|ru|sr|si|sk|sl|so|es|es-MX|sw|sv|ta|te|th|tr|uk|ur|uz|vi|cy]
                                   source language  [default: en]
   --dest-lang [af|sq|am|ar|hy|az|bn|bs|bg|ca|zh|zh-TW|hr|cs|da|fa-AF|nl|en|et|fa|tl|fi|fr|fr-CA|ka|de|el|gu|ht|ha|he|hi|hu|is|id|ga|it|ja|kn|kk|ko|lv|lt|mk|ms|ml|mt|mr|mn|no|ps|pl|pt|pt-PT|pa|ro|ru|sr|si|sk|sl|so|es|es-MX|sw|sv|ta|te|th|tr|uk|ur|uz|vi|cy]
@@ -37,4 +38,4 @@ Options:
 
 ## Acknowledgments
 
-Many thanks to  you for your tremendous contribution.
+Many thanks to you for your tremendous contribution.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip3 install git+https://github.com/riita10069/md-translate.git
 Options:
   --path PATH                     directory or file path where you want to
                                   translate  [required]
-  --r                             translate recursively for subdirectories
+  -r, --recursive                 translate recursively for subdirectories
   --src-lang [af|sq|am|ar|hy|az|bn|bs|bg|ca|zh|zh-TW|hr|cs|da|fa-AF|nl|en|et|fa|tl|fi|fr|fr-CA|ka|de|el|gu|ht|ha|he|hi|hu|is|id|ga|it|ja|kn|kk|ko|lv|lt|mk|ms|ml|mt|mr|mn|no|ps|pl|pt|pt-PT|pa|ro|ru|sr|si|sk|sl|so|es|es-MX|sw|sv|ta|te|th|tr|uk|ur|uz|vi|cy]
                                   source language  [default: en]
   --dest-lang [af|sq|am|ar|hy|az|bn|bs|bg|ca|zh|zh-TW|hr|cs|da|fa-AF|nl|en|et|fa|tl|fi|fr|fr-CA|ka|de|el|gu|ht|ha|he|hi|hu|is|id|ga|it|ja|kn|kk|ko|lv|lt|mk|ms|ml|mt|mr|mn|no|ps|pl|pt|pt-PT|pa|ro|ru|sr|si|sk|sl|so|es|es-MX|sw|sv|ta|te|th|tr|uk|ur|uz|vi|cy]

--- a/mdt.py
+++ b/mdt.py
@@ -112,7 +112,7 @@ def run(path, r, src_lang, dest_lang, output, debug):
 
         else:
             for filename in os.listdir(path):
-                if os.path.isfile(filename):
+                if os.path.isfile(os.path.join(path, filename)):
                     if (filename.endswith("." + src_lang + ".md") or (
                             src_lang == const.LANG_EN and "." not in filename.split("/")[-1].rstrip(".md"))):
                         click.echo("translate " + os.path.join(path, filename.removesuffix('.md')))

--- a/mdt.py
+++ b/mdt.py
@@ -16,16 +16,15 @@ def get_dest_file_path(filename, src_lang, dest_lang, output):
     dest_file_path = ''
     output_directory = Path.resolve(Path(output))
     current_directory = Path.cwd()
+
     if output_directory == current_directory:
-        dest_file_path = Path.resolve(Path('.' + filename.strip('.' + src_lang) + '.' + dest_lang + '.md'))
+        dest_file_path = Path.resolve(Path('.' + filename + '.md' if dest_lang == const.LANG_EN else filename + '.' + dest_lang + '.md'))
         dest_file_path = str(dest_file_path)
     else:
         md_file_name = Path(filename).name
-        dest_file_path = os.path.join(output_directory, md_file_name.strip('.' + src_lang) + '.md')
+        dest_file_path = os.path.join(output_directory, md_file_name + '.md' if src_lang == const.LANG_EN else md_file_name + '.' + src_lang + '.md')
         dest_file_path = re.sub(r"^./|/(\./)+", "/", dest_file_path)
 
-    if dest_file_path.endswith('.en.md'):
-        return dest_file_path.replace('.en.md', '.md')
     return str(dest_file_path)
 
 

--- a/mdt.py
+++ b/mdt.py
@@ -83,7 +83,7 @@ def mutate_path(ctx, param, value):
 @click.command()
 @click.option('--path', help='directory or file path where you want to translate', required=True,
               callback=mutate_path, type=click.Path(exists=True))
-@click.option('--r', is_flag=True, help='translate recursively for subdirectories', show_default=True)
+@click.option('-r', '--recursive', is_flag=True, help='translate recursively for subdirectories', show_default=True)
 @click.option('--src-lang', help='source language', default=const.LANG_EN, show_default=True,
               type=click.Choice(const.LANGUAGE_LIST))
 @click.option('--dest-lang', help='post-translation language', default=const.LANG_JA, show_default=True,
@@ -91,7 +91,7 @@ def mutate_path(ctx, param, value):
 @click.option('--output', help='directory where you want to output the translated contents', default="./",
               show_default=True, type=click.Path(exists=True))
 @click.option('--debug', is_flag=True, help='output some ast files for debug', show_default=True)
-def run(path, r, src_lang, dest_lang, output, debug):
+def run(path, recursive, src_lang, dest_lang, output, debug):
     if path.endswith(".md"):
         if (path.endswith("." + src_lang + ".md") or (
                     src_lang == const.LANG_EN and "." not in path.split("/")[-1].rstrip(".md"))):
@@ -99,7 +99,7 @@ def run(path, r, src_lang, dest_lang, output, debug):
                 path.removesuffix('.md') if src_lang == const.LANG_EN else path.removesuffix('.' + src_lang + '.md'),
                 src_lang, dest_lang, output, debug)
     else:
-        if r:
+        if recursive:
             for current_dir, dirs, files in os.walk(path):
                 for filename in files:
                     if (filename.endswith("." + src_lang + ".md") or (

--- a/mdt.py
+++ b/mdt.py
@@ -84,6 +84,7 @@ def mutate_path(ctx, param, value):
 @click.command()
 @click.option('--path', help='directory or file path where you want to translate', required=True,
               callback=mutate_path, type=click.Path(exists=True))
+@click.option('--r', is_flag=True, help='translate recursively for subdirectories', show_default=True)
 @click.option('--src-lang', help='source language', default=const.LANG_EN, show_default=True,
               type=click.Choice(const.LANGUAGE_LIST))
 @click.option('--dest-lang', help='post-translation language', default=const.LANG_JA, show_default=True,
@@ -91,7 +92,7 @@ def mutate_path(ctx, param, value):
 @click.option('--output', help='directory where you want to output the translated contents', default="./",
               show_default=True, type=click.Path(exists=True))
 @click.option('--debug', is_flag=True, help='output some ast files for debug', show_default=True)
-def run(path, src_lang, dest_lang, output, debug):
+def run(path, r, src_lang, dest_lang, output, debug):
     if path.endswith(".md"):
         if (path.endswith("." + src_lang + ".md") or (
                     src_lang == const.LANG_EN and "." not in path.split("/")[-1].rstrip(".md"))):
@@ -99,14 +100,25 @@ def run(path, src_lang, dest_lang, output, debug):
                 path.removesuffix('.md') if src_lang == const.LANG_EN else path.removesuffix('.' + src_lang + '.md'),
                 src_lang, dest_lang, output, debug)
     else:
-        for filename in os.listdir(path):
-            if os.path.isfile(filename):
-                if (filename.endswith("." + src_lang + ".md") or (
-                        src_lang == const.LANG_EN and "." not in filename.split("/")[-1].rstrip(".md"))):
-                    click.echo("translate " + os.path.join(path, filename.removesuffix('.md')))
-                    translate_page(
-                        os.path.join(path, filename).removesuffix('.md') if src_lang == const.LANG_EN else os.path.join(
-                            path, filename).removesuffix('.' + src_lang + '.md'), src_lang, dest_lang, output, debug)
+        if r:
+            for current_dir, dirs, files in os.walk(path):
+                for filename in files:
+                    if (filename.endswith("." + src_lang + ".md") or (
+                            src_lang == const.LANG_EN and "." not in filename.rstrip(".md"))):
+                        click.echo("translate " + os.path.join(current_dir, filename.removesuffix('.md')))
+                        translate_page(
+                            os.path.join(current_dir, filename).removesuffix('.md') if src_lang == const.LANG_EN else os.path.join(
+                                current_dir, filename).removesuffix('.' + src_lang + '.md'), src_lang, dest_lang, output, debug)
+
+        else:
+            for filename in os.listdir(path):
+                if os.path.isfile(filename):
+                    if (filename.endswith("." + src_lang + ".md") or (
+                            src_lang == const.LANG_EN and "." not in filename.split("/")[-1].rstrip(".md"))):
+                        click.echo("translate " + os.path.join(path, filename.removesuffix('.md')))
+                        translate_page(
+                            os.path.join(path, filename).removesuffix('.md') if src_lang == const.LANG_EN else os.path.join(
+                                path, filename).removesuffix('.' + src_lang + '.md'), src_lang, dest_lang, output, debug)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
         name='mdt',
         version='1.0.0',
         py_modules=['mdt'],
+        packages=['modules'],
         install_requires=['PyYAML==6.0', 'click==8.1.3', 'boto3==1.26.71'],
         entry_points={
             "console_scripts": ['mdt = mdt:run']


### PR DESCRIPTION
- setup.pyを修正
  - pip install時にmodules配下のファイルがダウンロードされるようにした
- mdt.pyを修正
  - 再帰オプションを追加
  - ファイル判定の部分でfilenameの前にpathを追加(そうしないと動かない)
  - get_dest_file_path関数の出力ファイル名を修正(stripによって、sourceがenのときにsample -> samplになってしまうような問題を解消)
    - パスが同じときはdest_langをつける
    - パスが異なるときは元のファイル名のまま 